### PR TITLE
fix Base.inherits()

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -29,11 +29,13 @@ var Base = Extendable.extend({
     },
 
     // Sets up inheritance from the given parent class. If the constructor
-    // isn't supplied then a default constructor is added which calls
-    // `initialize` for each class in the inheritance hierarchy.
+    // isn't supplied then a default constructor is added which invokes
+    // the parent then calls `initialize` for each class in the
+    // inheritance hierarchy.
     inherits: function(parent, protoProps, staticProps) {
         if (!protoProps.hasOwnProperty('constructor')) {
             protoProps.constructor = function() {
+                parent.apply(this);
                 Base._init_all(Object.getPrototypeOf(this), this, arguments);
             };
         }

--- a/specs/inherits.spec.js
+++ b/specs/inherits.spec.js
@@ -1,0 +1,22 @@
+
+var Base = require('extendable-base');
+var expect = require('chai').expect;
+
+describe("base class", function() {
+    function BaseClass() {
+        this.base_was_here = true;
+    }
+    
+    var DerivedClass = Base.inherits(BaseClass, {
+        initialize: function() {
+            this.derived_was_here = true;
+        }
+    });
+
+    it("calls base class constructor", function() {
+        var d = new DerivedClass();
+        
+        expect(d.base_was_here).to.equal(true);
+        expect(d.derived_was_here).to.equal(true);
+    });
+});


### PR DESCRIPTION
Base.inherits() previously didn't actually call the parent
function.  fix that here and add a test.
